### PR TITLE
'install oh-my-zsh' task now respects 'user' param

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   apt: pkg=zsh state=present
 
 - name: install oh-my-zsh
-  git: repo=https://github.com/robbyrussell/oh-my-zsh dest=~/.oh-my-zsh
+  git: repo=https://github.com/robbyrussell/oh-my-zsh dest=~{{user}}/.oh-my-zsh
   sudo: false
 
 - name: Backing up existing ~/.zshrc


### PR DESCRIPTION
As of now, oh-my-zsh will always be cloned in the home of the current ansible user. This will inhibit the correct installation when ansible is not run as the targeted user (e.g. root on new systems)